### PR TITLE
Version 1.21.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "hatchling" %}
-{% set version = "1.18.0" %}
+{% set version = "1.21.1" %}
 {% set build = "1" %}
-{% set checksum = "50e99c3110ce0afc3f7bdbadff1c71c17758e476731c27607940cfa6686489ca" %}
+{% set checksum = "bba440453a224e7d4478457fa2e8d8c3633765bafa02975a6b53b9bf917980bc" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: {{ build }}
-  skip: True  # [py<37]
+  skip: True  # [py<38]
   entry_points:
     - hatchling = hatchling.cli:hatchling
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "hatchling" %}
 {% set version = "1.21.1" %}
-{% set build = "1" %}
+{% set build = "0" %}
 {% set checksum = "bba440453a224e7d4478457fa2e8d8c3633765bafa02975a6b53b9bf917980bc" %}
 
 package:


### PR DESCRIPTION
hatcling 1.21.1

**Destination channel:** defaults

### Links

- [PKG-4064](https://anaconda.atlassian.net/browse/PKG-4064)
- [Upstream repository](https://github.com/pypa/hatch/tree/hatchling-v1.21.1/backend)
- [Upstream changelog/diff](https://hatch.pypa.io/latest/history/hatchling/)

### Explanation of changes:

- Update version and `sha256`
- Reset build number
- Update python build skip to `<38`


[PKG-4064]: https://anaconda.atlassian.net/browse/PKG-4064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ